### PR TITLE
Allow longer strings in json dicts utilities

### DIFF
--- a/lib/udf_json_dicts.rb
+++ b/lib/udf_json_dicts.rb
@@ -4,8 +4,8 @@ class UdfJsonDicts
           type:        :function,
           name:        :json_extract_path_keys,
           description: "Return the list of keys in a json dict as a json string",
-          params:      "jsonstr varchar(max)",
-          return_type: "varchar(max)",
+          params:      "jsonstr varchar(10000)",
+          return_type: "varchar(10000)",
           body:        %~
             import json
             if not jsonstr:
@@ -22,14 +22,14 @@ class UdfJsonDicts
           type:        :function,
           name:        :json_extract_path_key,
           description: "Return a specific key of a json dict",
-          params:      "jsonstr varchar(max), pos integer, reverse boolean",
-          return_type: "varchar(max)",
+          params:      "jsonstr varchar(10000), pos integer",
+          return_type: "varchar(10000)",
           body:        %~
             import json
             if not jsonstr:
               return ''
             else:
-              keys = sorted(json.loads(str(jsonstr)).keys(), reverse=reverse)
+              keys = sorted(json.loads(str(jsonstr)).keys())
               if len(keys) <= pos:
                 return ''
               else:
@@ -37,9 +37,7 @@ class UdfJsonDicts
           ~,
           tests:       [
                            {query: "select ?('{\"a\": \"A\", \"b\": \"B\"}', 0)", expect: 'a', example: true},
-                           {query: "select ?('{\"a\": \"A\", \"b\": \"B\"}', 0, True)", expect: 'b', example: true},
                            {query: "select ?('{\"a\": \"A\", \"b\": \"B\"}', 1)", expect: 'b', example: true},
-                           {query: "select ?('{\"a\": \"A\", \"b\": \"B\"}', 1, True)", expect: 'a', example: true}
                        ]
       }
   ]


### PR DESCRIPTION
Apparently `varchar(max)` means `varchar(256)` for Redshift:

https://forums.aws.amazon.com/message.jspa?messageID=685756

That is too short for some of the experiments dicts we get from the NFH and caused the corresponding ETL step to fail. I have already loaded this modified version of the UDFs in Redshift and rerun the failed ETL job.

Also this PR removes the `reverse` argument from the `json_extract_path_key` function. The reason is that this function is already used in many places in Redshift without that argument. Adding the argument causes those calls that don't specify `reverse` to break. 